### PR TITLE
Adds Mono/Stereo Support Toggled by a Define in midi-sound-module.ino

### DIFF
--- a/arduino-midi-sound-module/arduino-midi-sound-module.ino
+++ b/arduino-midi-sound-module/arduino-midi-sound-module.ino
@@ -71,7 +71,15 @@
 
 // Defining 'USE_HAIRLESS_MIDI' will set the serial baud rate to 38400.  Comment out the
 // below #define to use standard MIDI speed of 31250 baud.
-#define USE_HAIRLESS_MIDI
+
+// #define USE_HAIRLESS_MIDI
+
+// Set mono/stereo operation.  Comment out all the below #define comments to set mono
+// operation.  Defining STEREO and LEFT or RIGHT will enable stereo mode.
+
+// #define STEREO
+// #define LEFT
+// #define RIGHT
 
 // See "main.h" for the definitions of `setup()` and `loop()`
 #include "main.h"

--- a/arduino-midi-sound-module/main.cpp
+++ b/arduino-midi-sound-module/main.cpp
@@ -4,9 +4,12 @@
 */
 
 /*
-    Baseline:
-		Program Memory Usage:	22526 bytes	69 % Full
-		Data Memory Usage:	1116 bytes	54 % Full
+    Baseline MONO:
+	Program Memory Usage:	22262 bytes   69 % Full
+	Data Memory Usage:	1084 bytes    52 % Full
+    Baseline STEREO:
+	Program Memory Usage:	22526 bytes   69 % Full
+	Data Memory Usage:	1116 bytes    54 % Full
 */
 
 #ifndef ARDUINO

--- a/arduino-midi-sound-module/main.cpp
+++ b/arduino-midi-sound-module/main.cpp
@@ -5,11 +5,11 @@
 
 /*
     Baseline MONO:
-	Program Memory Usage:	22262 bytes   69 % Full
-	Data Memory Usage:	1084 bytes    52 % Full
+				Program Memory Usage 	:	22262 bytes   69 % Full
+				Data Memory Usage 		:	1084 bytes    52 % Full
     Baseline STEREO:
-	Program Memory Usage:	22526 bytes   69 % Full
-	Data Memory Usage:	1116 bytes    54 % Full
+				Program Memory Usage 	:	22526 bytes   69 % Full
+				Data Memory Usage 		:	1116 bytes    54 % Full
 */
 
 #ifndef ARDUINO
@@ -19,5 +19,5 @@
 // point ("main.cpp") and the Arduino IDE entry point ("arduino-midi-sound-module.ino").
 #include "main.h"
 
-#endif  // !__EMSCRIPTEN__
-#endif  // !ARDUINO
+#endif // !__EMSCRIPTEN__
+#endif // !ARDUINO

--- a/arduino-midi-sound-module/main.cpp
+++ b/arduino-midi-sound-module/main.cpp
@@ -1,12 +1,12 @@
-﻿/*
+/*
     Entry point when compiling with Atmel Studio
     https://github.com/DLehenbauer/arduino-midi-sound-module
 */
 
 /*
     Baseline:
-				Program Memory Usage 	:	22314 bytes   68.1 % Full
-				Data Memory Usage 		:	1086 bytes   53.0 % Full
+		Program Memory Usage:	22526 bytes	69 % Full
+		Data Memory Usage:	1116 bytes	54 % Full
 */
 
 #ifndef ARDUINO
@@ -16,5 +16,5 @@
 // point ("main.cpp") and the Arduino IDE entry point ("arduino-midi-sound-module.ino").
 #include "main.h"
 
-#endif // !__EMSCRIPTEN__
-#endif // !ARDUINO
+#endif  // !__EMSCRIPTEN__
+#endif  // !ARDUINO

--- a/arduino-midi-sound-module/midisynth.h
+++ b/arduino-midi-sound-module/midisynth.h
@@ -14,165 +14,179 @@
 #include "synth.h"
 
 class MidiSynth final : public Synth {
-  private:
-    constexpr static uint8_t numMidiChannels    = 16;                   // MIDI standard has 16 channels.
-    constexpr static uint8_t maxMidiChannel     = numMidiChannels - 1;  // Maximum channel is 15 when 0-indexed.
-    constexpr static uint8_t percussionChannel  = 9;                    // Channel 10 is percussion (9 when 0-indexed).
+private:
+  constexpr static uint8_t numMidiChannels = 16;                  // MIDI standard has 16 channels.
+  constexpr static uint8_t maxMidiChannel = numMidiChannels - 1;  // Maximum channel is 15 when 0-indexed.
+  constexpr static uint8_t percussionChannel = 9;                 // Channel 10 is percussion (9 when 0-indexed).
 
-    static uint8_t voiceToNote[numVoices];                      // Map synth voice to the current MIDI note (or 0xFF if off).
-    static uint8_t voiceToChannel[numVoices];                   // Map synth voice to the current MIDI channel (or 0xFF if off).
-    static Instrument channelToInstrument[numMidiChannels];     // Map MIDI channel to the current MIDI program (i.e., instrument).
-    static uint8_t channelToVolume[numMidiChannels];            // Map MIDI channel to the current 8-bit instrument volume.
-    static uint8_t channelToPan[numMidiChannels];               // Map MIDI channel to the current 8-bit pan volume.
-    static uint8_t channelToPanInv[numMidiChannels];            // Map MIDI channel to the current inverse of the 8-bit pan volume.
-    static uint8_t voiceToVolume[numVoices];                    // Map synth voice to 8-bit volume scalar.
-    static uint8_t voiceToVelocity[numVoices];                  // Map synth voice to 7-bit velocity scalar.
+  static uint8_t voiceToNote[numVoices];                   // Map synth voice to the current MIDI note (or 0xFF if off).
+  static uint8_t voiceToChannel[numVoices];                // Map synth voice to the current MIDI channel (or 0xFF if off).
+  static Instrument channelToInstrument[numMidiChannels];  // Map MIDI channel to the current MIDI program (i.e., instrument).
+  static uint8_t channelToVolume[numMidiChannels];         // Map MIDI channel to the current 8-bit instrument volume.
+  static uint8_t channelToPan[numMidiChannels];            // Map MIDI channel to the current 8-bit pan volume.
+  static uint8_t channelToPanInv[numMidiChannels];         // Map MIDI channel to the current inverse of the 8-bit pan volume.
+  static uint8_t voiceToVolume[numVoices];                 // Map synth voice to 8-bit volume scalar.
+  static uint8_t voiceToVelocity[numVoices];               // Map synth voice to 7-bit velocity scalar.
 
-  public:
-    MidiSynth() : Synth() {
-      for (int8_t channel = maxMidiChannel; channel >= 0; channel--) {
-        Instruments::getInstrument(0, channelToInstrument[channel]);
+public:
+  MidiSynth()
+    : Synth() {
+    for (int8_t channel = maxMidiChannel; channel >= 0; channel--) {
+      Instruments::getInstrument(0, channelToInstrument[channel]);
+    }
+  }
+
+  void midiNoteOn(uint8_t channel, uint8_t note, uint8_t velocity) {
+    if (channel == percussionChannel) {             // If playing the percussion channel
+      note = Instruments::getPercussiveInstrument(  // Update the channel instrument for the given note, and
+        note, channelToInstrument[channel]);        // replace the note with the correct playback frequency
+    }                                               // for the instrument (expressed as a midi note).
+
+    uint8_t voice = getNextVoice();  // Find an available voice and play the note.
+
+    // Combine the incoming velocity with the current channel volume and pan scalar.
+    voiceToVelocity[voice] = velocity;
+    uint8_t volume = mixVolume(channelToVolume[channel], velocity, channelToPan[channel], channelToPanInv[channel]);
+
+    noteOn(voice, note, volume, channelToInstrument[channel]);
+
+    voiceToNote[voice] = note;        // Update our voice -> note/channel maps (used for processing MIDI
+    voiceToChannel[voice] = channel;  // pitch bend and note off messages).
+  }
+
+  void midiNoteOff(uint8_t channel, uint8_t note) {
+    for (int8_t voice = maxVoice; voice >= 0; voice--) {                     // For each voice
+      if (voiceToNote[voice] == note && voiceToChannel[voice] == channel) {  // that is currently playing the note on this channel
+        noteOff(voice);                                                      // stop playing the note
       }
     }
+  }
 
-    void midiNoteOn(uint8_t channel, uint8_t note, uint8_t velocity) {
-      if (channel == percussionChannel) {               // If playing the percussion channel
-        note = Instruments::getPercussiveInstrument(    //   Update the channel instrument for the given note, and
-          note, channelToInstrument[channel]);          //   replace the note with the correct playback frequency
-      }                                                 //   for the instrument (expressed as a midi note).
+  void midiProgramChange(uint8_t channel, uint8_t program) {
+    channelToPan[channel] = 0x80;     // Most MIDI files seem to set the PAN shortly after setting the patch
+    channelToPanInv[channel] = 0x7F;  // so we reset these values in case the new patch doesn't have PAN values
 
-      uint8_t voice = getNextVoice();                   // Find an available voice and play the note.
+    channelToVolume[channel] = 0xFF;  // Same idea as above, probably unnecessary?
 
-      // Combine the incoming velocity with the current channel volume and pan scalar.
-      voiceToVelocity[voice] = velocity;
-      uint8_t volume = mixVolume(channelToVolume[channel], velocity, channelToPan[channel], channelToPanInv[channel]);
+    Instruments::getInstrument(program, channelToInstrument[channel]);  // Load the instrument corresponding to the given MIDI program
+  }                                                                     // into the MIDI channel -> instrument map.
 
-      noteOn(voice, note, volume, channelToInstrument[channel]);
-
-      voiceToNote[voice] = note;                        // Update our voice -> note/channel maps (used for processing MIDI
-      voiceToChannel[voice] = channel;                  // pitch bend and note off messages).
-    }
-
-    void midiNoteOff(uint8_t channel, uint8_t note)  {
-      for (int8_t voice = maxVoice; voice >= 0; voice--) {                      // For each voice
-        if (voiceToNote[voice] == note && voiceToChannel[voice] == channel) {   //   that is currently playing the note on this channel
-          noteOff(voice);                                                       //      stop playing the note
-        }
+  void midiPitchBend(uint8_t channel, int16_t value) {
+    for (int8_t voice = maxVoice; voice >= 0; voice--) {  // For each voice
+      if (voiceToChannel[voice] == channel) {             //   which is currently playing a note on this channel
+        pitchBend(voice, value);                          //     update pitch bench with the given value.
       }
     }
+  }
 
-    void midiProgramChange(uint8_t channel, uint8_t program) {
-        channelToPan[channel] = 0x80                                            // Most MIDI files seem to set the PAN shortly after setting the patch
-        channelToPanInv[channel] = 0x7F                                         // so we reset these values in case the new patch doesn't have PAN values
+  // Combines the given channel volume, note velocity, and pan scalar into a single volume for the
+  // synth.  (Inputs and outputs are all 7 bit).
+  uint8_t mixVolume(uint8_t volume, uint8_t velocity, uint8_t pan, uint8_t panInv) {
 
-        channelToVolume[channel] = 0xFF                                         // Same idea as above, probably unnecessary?
+    // Map 8-bit channel volume and 7-bit velocity to 7-bit monoVolume.  We've scaled MIDI
+    // channel volume up to 8-bit so that we can perform an inexpensive '>> 8'. Stores in a temporary uint8_t
+    // while we check to see if there is a pan scalar for this voice.
 
-        Instruments::getInstrument(program, channelToInstrument[channel]);      // Load the instrument corresponding to the given MIDI program
-    }                                                                           // into the MIDI channel -> instrument map.
+  uint8_t monoVolume = static_cast<uint16_t>(volume) * static_cast<uint16_t>(velocity) >> 8;
 
-    void midiPitchBend(uint8_t channel, int16_t value) {
-      for (int8_t voice = maxVoice; voice >= 0; voice--) {                      // For each voice
-        if (voiceToChannel[voice] == channel) {                                 //   which is currently playing a note on this channel
-          pitchBend(voice, value);                                              //     update pitch bench with the given value.
-        }
-      }
+    // This is the configuration for the LEFT Arduino
+	    if (pan > 128) {                                                                           // Check to see if there is a pan scalar pointing to the RIGHT channel
+	      uint8_t monoVolumeShifted = monoVolume << 1;                                             // shift the monoVolume to enable the calculation below
+	      return (static_cast<uint16_t>(monoVolumeShifted) * static_cast<uint16_t>(panInv)) >> 8;  // combine the monoVolume with the pan scalar and
+
+      // This would be the configuration for the RIGHT Arduino
+      //     if (panInv>127) {
+      //         uint8_t monoVolumeShifted = monoVolume << 1;
+      //         return (static_cast<uint16_t>(monoVolumeShifted) * static_cast<uint16_t>(pan)) >> 8;
+
+    } else {
+      return (monoVolume);
     }
+  }
 
-    // Combines the given channel volume, note velocity, and pan scalar into a single volume for the
-    // synth.  (Inputs and outputs are all 7 bit).
-    uint8_t mixVolume(uint8_t volume, uint8_t velocity, uint8_t pan, uint8_t panInv) {
-     
-        uint8_t monoVolume = static_cast<uint16_t>(volume) * static_cast<uint16_t>(velocity) >> 8;
-            
-     // This is the configuration for the LEFT Arduino
-	        if (pan>128) {
-                uint8_t monoVolumeShifted = monoVolume << 1;
-                return (static_cast<uint16_t>(monoVolumeShifted) * static_cast<uint16_t>(panInv)) >> 8;
-
-     // This would be the configuration for the RIGHT Arduino
-     //     if (panInv>127) {
-     //         uint8_t monoVolumeShifted = monoVolume << 1;
-     //         return (static_cast<uint16_t>(monoVolumeShifted) * static_cast<uint16_t>(pan)) >> 8;
-                
-            } else {
-                return (monoVolume);
-                   }
-    }
-    
-    void midiControlChange(uint8_t channel, uint8_t controller, uint8_t value) {
-      switch (controller) {
-        // Set channel volume
-        case 0x07: {
+  void midiControlChange(uint8_t channel, uint8_t controller, uint8_t value) {
+    switch (controller) {
+      // Set channel volume
+      case 0x07:
+        {
           // Scale 7-bit MIDI channel volume up to 8-bit.  This reduces the instructions require to convert
           // from 16-bit to 8-bit later in mixVolume().
           value <<= 1;
 
           channelToVolume[channel] = value;
-          for (int8_t voice = maxVoice; voice >= 0; voice--) {      // For each voice
-            if (voiceToChannel[voice] == channel) {                 //   currently playing any note on this channel
+          for (int8_t voice = maxVoice; voice >= 0; voice--) {  // For each voice
+            if (voiceToChannel[voice] == channel) {             //   currently playing any note on this channel
               // Combine the incoming channel volume with the current note velocity and pan scalar.
               setVolume(voice, mixVolume(value, voiceToVelocity[voice], channelToPan[channel], channelToPanInv[channel]));
             }
           }
           break;
         }
-        
-        // Set channel pan (by adjusting volume)
-        case 0x0A: {
-            
-          value <<=1;
+
+      // Set channel pan (by adjusting volume)
+      case 0x0A:
+        {
+          // Scale 7-bit MIDI pan scalar up to 8-bit.  This reduces the instructions require to convert
+          // from 16-bit to 8-bit later in mixVolume().
+          value <<= 1;
+
           channelToPan[channel] = value;
-          channelToPanInv[channel] = ~value;
-            for (int8_t voice = maxVoice; voice >= 0; voice--) {        // For each voice
-                if (voiceToChannel[voice] == channel) {                 // currently playing any note on this channel
-                    // Combine the incoming pan volume with the current note velocity and channel volume.
-                  setVolume(voice, mixVolume(channelToVolume[channel], voiceToVelocity[voice], value, valueInverted));
-                }
-            }
-            break;
-        }
-        
-        case 0x78: {
-          switch (value) {
-            case 0: {
-              // All Sound Off (for current channel):
-              for (int8_t voice = maxVoice; voice >= 0; voice--) {  // For each voice
-                if (voiceToChannel[voice] == channel) {             //   currently playing any note on this channel
-                  noteOff(voice);                                   //     stop playing the note
-                  setVolume(voice, 0);                              //     immediately silence the voice
-                }
-              }
-              break;
+          uint8_t valueInverted = ~value;
+          channelToPanInv[channel] = valueInverted;
+          for (int8_t voice = maxVoice; voice >= 0; voice--) {  // For each voice
+            if (voiceToChannel[voice] == channel) {             // currently playing any note on this channel
+              // Combine the incoming pan volume with the current note velocity and channel volume.
+              setVolume(voice, mixVolume(channelToVolume[channel], voiceToVelocity[voice], value, valueInverted));
             }
           }
           break;
         }
-        
-        case 0x7B: {
+
+      case 0x78:
+        {
           switch (value) {
-            case 0: {                                                    
-              // All Notes Off (for current channel):
-              for (int8_t voice = maxVoice; voice >= 0; voice--) {  // For each voice
-                if (voiceToChannel[voice] == channel) {             //   currently playing any note on this channel
-                  noteOff(voice);                                   //     stop playing the note
+            case 0:
+              {
+                // All Sound Off (for current channel):
+                for (int8_t voice = maxVoice; voice >= 0; voice--) {  // For each voice
+                  if (voiceToChannel[voice] == channel) {             // currently playing any note on this channel
+                    noteOff(voice);                                   // stop playing the note
+                    setVolume(voice, 0);                              // immediately silence the voice
+                  }
                 }
+                break;
               }
-              break;
-            }
           }
           break;
         }
-      }
+
+      case 0x7B:
+        {
+          switch (value) {
+            case 0:
+              {
+                // All Notes Off (for current channel):
+                for (int8_t voice = maxVoice; voice >= 0; voice--) {  // For each voice
+                  if (voiceToChannel[voice] == channel) {             // currently playing any note on this channel
+                    noteOff(voice);                                   // stop playing the note
+                  }
+                }
+                break;
+              }
+          }
+          break;
+        }
     }
-}; //MidiSynth
+  }
+};  //MidiSynth
 
-uint8_t     MidiSynth::voiceToNote[numVoices]               = { 0 };
-uint8_t     MidiSynth::voiceToChannel[numVoices]            = { 0 };
-Instrument  MidiSynth::channelToInstrument[numMidiChannels] = { 0 };
-uint8_t     MidiSynth::channelToVolume[numMidiChannels]     = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
-uint8_t     MidiSynth::channelToPan[numMididChannels]       = { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 };
-uint8_t     MidiSynth::channelToPanInv[numMididChannels]    = { 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F };
-uint8_t     MidiSynth::voiceToVolume[numVoices]             = { 0 };
-uint8_t     MidiSynth::voiceToVelocity[numVoices]           = { 0 };
+uint8_t MidiSynth::voiceToNote[numVoices] = { 0 };
+uint8_t MidiSynth::voiceToChannel[numVoices] = { 0 };
+Instrument MidiSynth::channelToInstrument[numMidiChannels] = { 0 };
+uint8_t MidiSynth::channelToVolume[numMidiChannels] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+uint8_t MidiSynth::channelToPan[numMidiChannels] = { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 };
+uint8_t MidiSynth::channelToPanInv[numMidiChannels] = { 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F, 0x7F };
+uint8_t MidiSynth::voiceToVolume[numVoices] = { 0 };
+uint8_t MidiSynth::voiceToVelocity[numVoices] = { 0 };
 
-#endif //__MIDISYNTH_H__
+#endif  //__MIDISYNTH_H__


### PR DESCRIPTION
Hello,

This pull request adds preliminary support for change control 10 (aka stereo panning) to the midisynth.h.  It is intended to allow the use of two separate Arduinos for the left and right channels.   Because of the bit shifting used (the usable portion of the pan value is a six-bit integer), when stereo mode is enabled the maximum volume when panning is used is 126, and not 127.  I did a reformatting pass of midisynth.h because it was sort of a mess after I had moved things around -- the changes are not as extensive as they seem, most is just making things line up with the code I added.

By commenting out all defines in midi-sound-module.ino the synth behaves as you originally coded it with no modifications.  When BOTH STEREO and either LEFT or RIGHT are defined the synth then checks for change control 10 (case 0x0A), shifts left one bit to let us work with the whole uint8, and then updates each voice currently playing on that channel.  The mixVolume function is reworked to respect the pan value stored for each channel every time the volume is updated.  Some arrays were created to store the pan and inverse pan for each channel.

I am a novice programmer (first pull request even!) so, if this isn't up to your standards (or you don't want niche-case use case stereo code clogging up your repo) feel free to deny.  I'll keep my fork open so people can still find it if they are so inclined.

Thanks for the awesome project!
Evan